### PR TITLE
Allow tag if no change to code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -116,7 +116,7 @@ tag_commit=$(git rev-list -n 1 "$tag")
 # get current commit hash
 commit=$(git rev-parse HEAD)
 
-if [ "$tag_commit" == "$commit" ] && [ $allow_tag_on_unchanged = false ]
+if [ "$tag_commit" == "$commit" ] && [ "$allow_tag_on_unchanged" == "false" ]
 then
     echo "No new commits since previous tag. Skipping..."
     setOutput "new_tag" "$tag"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ major_string_token=${MAJOR_STRING_TOKEN:-#major}
 minor_string_token=${MINOR_STRING_TOKEN:-#minor}
 patch_string_token=${PATCH_STRING_TOKEN:-#patch}
 none_string_token=${NONE_STRING_TOKEN:-#none}
+allow_tag_on_unchanged=${ALLOW_TAG_ON_UNCHANGED:-false}
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
 git config --global --add safe.directory /github/workspace
 
@@ -39,6 +40,7 @@ echo -e "\tMAJOR_STRING_TOKEN: ${major_string_token}"
 echo -e "\tMINOR_STRING_TOKEN: ${minor_string_token}"
 echo -e "\tPATCH_STRING_TOKEN: ${patch_string_token}"
 echo -e "\tNONE_STRING_TOKEN: ${none_string_token}"
+echo -e "\tALLOW_TAG_ON_UNCHANGED: ${allow_tag_on_unchanged}"
 
 # verbose, show everything
 if $verbose
@@ -114,7 +116,7 @@ tag_commit=$(git rev-list -n 1 "$tag")
 # get current commit hash
 commit=$(git rev-parse HEAD)
 
-if [ "$tag_commit" == "$commit" ]
+if [ "$tag_commit" == "$commit" ] && [ $allow_tag_on_unchanged = false ]
 then
     echo "No new commits since previous tag. Skipping..."
     setOutput "new_tag" "$tag"


### PR DESCRIPTION
Adds ALLOW_TAG_ON_UNCHANGED env var, false by default. If set to true, no not skip tag generation even if there is no change to the code.